### PR TITLE
Minor changes to work with a fresh 2015.2 install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,18 +120,24 @@ class gitolite (
   }
 
   case $::operatingsystemmajrelease {
-    7 : {
+    "7" : {
+      $gitolite_pkg = "gitolite3"
     }
     default : {
-      package {'gitolite' : }
+      $gitolite_pkg = "gitolite"
     }
   }
-  package {'gitolite3' : } ->
+  package {$gitolite_pkg : } ->
   user { 'git' :
     ensure     => present,
     comment    => 'git user',
     managehome => true,
     home       => $git_home,
+  } ->
+  file {"${git_home}" :
+    ensure => directory,
+    owner  => 'git',
+    group  => 'git',
   } ->
   file {"${git_home}/install.pub" :
     content => "${git_key_type} ${git_key} ${admin_user}",

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,7 @@
   "author": "jlcox1970",
   "dependencies": [
   	{ "name": "stahnma/epel", "version_requirement": ">= 0.0.6"}
+  	{ "name": "puppetlabs/concat", "version_requirement": ">= 1.2.0"}
   ],
   "license": "Apache-2.0",
   "name": "jlcox-gitolite",

--- a/templates/setup.sh.erb
+++ b/templates/setup.sh.erb
@@ -1,6 +1,5 @@
 #!/bin/bash
 export HOME=<%= @git_home %>
-chmod +rx /home
 chmod +rx <%= @git_home %>
 
 gitolite setup -pk <%= @git_home %>/install.pub


### PR DESCRIPTION
List of changes made:
- Fixed case statement to look for "7" instead of 7 since the return for operatingsystemmajrelease is a string and not an integer
- Added logic to set the gitolite package based on operatingsystemmajrelease so that it didn't fail and try to install gitolite twice if operatingsystemmajrelease was 7
- Ensured that git_home directory existed (in case user already existed, but had a different home directory)
- Added an entry to the metadata.json file to include the dependency on puppetlabs/concat
- Modified the setup.sh template to not chmod /home; not sure what the logic was for this, but in a lot of cases, the git user will not have the necessary permissions to modify this folder anyway
