### PR TITLE
remove useless notify

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -135,7 +135,7 @@ class gitolite (
       }
     }
   }
-  notify {"installing $gitolite_pkg on $osfamily and $::operatingsystemmajrelease":}
+
   package { $gitolite_pkg: } ->
   user { 'git':
     ensure     => present,


### PR DESCRIPTION
this will prevent Puppet showing an applied resource at every agent run even
if gitolite is already installed and setup
