### PR TITLE
Alternate repository root

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,17 @@ class gitolite (
     owner   => 'git',
     group   => 'git',
   } ->
+  file { 'repositories directory installer':
+    name    => "${git_home}/setup_repositories_dir.sh",
+    content => template("${module_name}/setup_repositories_dir.sh.erb"),
+  } ->
+  exec { 'install repositories directory':
+    cwd     => $git_home,
+    path    => '/usr/bin:/bin',
+    command => "${git_home}/setup_repositories_dir.sh",
+    user    => 'root',
+    creates => "${git_home}/repositories",
+  } ->
   file { 'git installer':
     name    => "${git_home}/setup.sh",
     content => template("${module_name}/setup.sh.erb"),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,11 @@
 #
 # [git_home]
 #   root directory for the repository.
-#     Defaults to the git users home direcotry (/home/git)
+#     Defaults to the git users home directory (/home/git)
+#
+# [git_root]
+#   root directory for the repository storage
+#     Defaults to  $git_home/repositories
 #
 # [auto_tag_serial]
 #   Adds an auto incrimental serial tag to each commit
@@ -51,14 +55,15 @@
 #
 class gitolite (
   $git_key         = undef,
-  $admin_user      = 'admin',
-  $git_key_type    = 'ssh-rsa',
-  $git_home        = '/home/git',
-  $r10k_exec       = '/usr/local/bin/r10k',
-  $auto_tag_serial = false,
-  $r10k_update     = false,
-  $extra_hooks     = undef,) {
-  $git_root    = "${git_home}/repositories"
+  $extra_hooks     = undef,
+  $admin_user      = $gitolite::params::admin_user,
+  $auto_tag_serial = $gitolite::params::auto_tag_serial,
+  $git_key_type    = $gitolite::params::git_key_type,
+  $git_home        = $gitolite::params::git_home,
+  $git_root        = $gitolite::params::git_root,
+  $r10k_exec       = $gitolite::params::r10k_exec,
+  $r10k_update     = $gitolite::params::r10k_update,
+) inherits gitolite::params {
   $hook        = "${git_home}/.gitolite/hooks/common"
   $hook_concat = "${hook}/post-receive"
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,15 @@
+# Andrew Grimberg <agrimberg@linuxfoundation.org>
+#
+# === Copyright
+#
+# Copyright 2016 Andrew Grimberg, unless otherwise noted
+#
+class gitolite::params {
+  $admin_user      = 'admin'
+  $auto_tag_serial = false
+  $git_key_type    = 'ssh-rsa'
+  $git_home        = '/home/git'
+  $git_root        = "${git_home}/repositories"
+  $r10k_exec       = '/usr/local/bin/r10k'
+  $r10k_update     = false
+}

--- a/templates/setup.sh.erb
+++ b/templates/setup.sh.erb
@@ -2,6 +2,17 @@
 export HOME=<%= @git_home %>
 chmod +rx <%= @git_home %>
 
+if [ "<%= @git_root %>" != "<%= @git_home %>/repositories" ]
+then
+    # Create the repository hosting path
+    mkdir -p <%= @git_root %>
+    chown git:git <%= @git_root %>
+
+    # Make sure that there is a symlink to the new path so gitolite will use the
+    # path for the repositories
+    ln -s <%= @git_root %> <%= @git_home %>/repositories
+fi
+
 gitolite setup -pk <%= @git_home %>/install.pub
 
 chmod +rx <%= @git_home %>/repositories -R

--- a/templates/setup.sh.erb
+++ b/templates/setup.sh.erb
@@ -2,19 +2,8 @@
 export HOME=<%= @git_home %>
 chmod +rx <%= @git_home %>
 
-if [ "<%= @git_root %>" != "<%= @git_home %>/repositories" ]
-then
-    # Create the repository hosting path
-    mkdir -p <%= @git_root %>
-    chown git:git <%= @git_root %>
-
-    # Make sure that there is a symlink to the new path so gitolite will use the
-    # path for the repositories
-    ln -s <%= @git_root %> <%= @git_home %>/repositories
-fi
-
 gitolite setup -pk <%= @git_home %>/install.pub
 
-chmod +rx <%= @git_home %>/repositories -R
+chmod +rx <%= @git_home %>/repositories/* -R
 chmod 700 <%= @git_home %>/repositories/gitolite-admin.git -R
 

--- a/templates/setup_repositories_dir.sh.erb
+++ b/templates/setup_repositories_dir.sh.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ "<%= @git_root %>" != "<%= @git_home %>/repositories" ]
+then
+    # Create the repository hosting path
+    mkdir -p <%= @git_root %>
+    chown git:git <%= @git_root %>
+
+    # Make sure that there is a symlink to the new path so gitolite will use the
+    # path for the repositories
+    ln -s <%= @git_root %> <%= @git_home %>/repositories
+else
+    mkdir <%= @git_home %>/repositories
+    chown git:git <%= @git_home %>/repositories
+    chmod +rx <%= @git_home %>/repositories
+fi


### PR DESCRIPTION
This patch series makes it possible to pass an alternate path for where
the gitolite repositories will be created.

The use case in particular is if you want to host anonymous repos on a
RedHat / CentOS flavor system which defaults to using /var/lib/git as
the hosting path. In particular, allowing for this means that there is
less work needed if SELinux is enabled on the system. Adding the
appropriate SELinux labels is still an exercise for the final
implementor ;)